### PR TITLE
Fix for ESBJAVA-3853

### DIFF
--- a/modules/distribution/src/main/conf/passthru-http.properties
+++ b/modules/distribution/src/main/conf/passthru-http.properties
@@ -33,7 +33,7 @@ http.socket.reuseaddr=true
 ## Other parameters
 #http.user.agent.preserve=false
 #http.server.preserve=true
-http.headers.preserve="CONTENT_TYPE"
+http.headers.preserve=Content-Type
 #http.connection.disable.keepalive=false
 rest.dispatcher.service=__MultitenantDispatcherService
 # URI configurations that determine if it requires custom rest dispatcher

--- a/modules/distribution/src/main/conf/passthru-http.properties
+++ b/modules/distribution/src/main/conf/passthru-http.properties
@@ -33,6 +33,7 @@ http.socket.reuseaddr=true
 ## Other parameters
 #http.user.agent.preserve=false
 #http.server.preserve=true
+http.headers.preserve="CONTENT_TYPE"
 #http.connection.disable.keepalive=false
 rest.dispatcher.service=__MultitenantDispatcherService
 # URI configurations that determine if it requires custom rest dispatcher


### PR DESCRIPTION
"CONTENT_TYPE" HTTP header is to be Preserved in default Pass Through case.
"http.headers.preserve" property was not found, null results in Removing the "CONTENT_TYPE" from HTTP headers. Added the property as a Fix.