### PR TITLE
Disabling the test case written for ESBJAVA-3899 due to a regression …

### DIFF
--- a/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
@@ -107,14 +107,16 @@
         </classes>
 	</test>
 
-	<test
+    <!-- Commented the test case due to a regression issue occurred due to this fix. 
+             Need to enable this test case once the original issue is fixed properly -->
+    <!--test
 		name="security-policy-reference-element-in-wsdl-bindings-for-capp-test"
 		preserve-order="true" verbose="2">
 		<classes>
 			<class
 				name="org.wso2.carbon.esb.security.policy.ESBJAVA3899_PolicyReferenceInWSDLBindingsTestCase" />
 		</classes>
-	</test>
+    </test-->
 
     <test name="proxy-start-on-load-false-test" preserve-order="true" verbose="2">
         <classes>


### PR DESCRIPTION
…issue occurred with the original fix. Original fix was reverted. Need to enable this once the original issue is fixed