### PR TITLE
JMSCAppDeploymentWithFaultyProxyTestCase, ESBJAVA2464TestCase updates

### DIFF
--- a/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2464TestCase.java
+++ b/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA2464TestCase.java
@@ -20,23 +20,11 @@ public class ESBJAVA2464TestCase extends ESBIntegrationTest {
 	private static final String logLine0 =
 	                                       "org.wso2.carbon.proxyadmin.service.ProxyServiceAdmin is not an admin service. Service name ";
 
-	private ServerConfigurationManager configurationManager;
 	private LogViewerClient logViewer;
 
 	@BeforeClass(alwaysRun = true)
 	public void setEnvironment() throws Exception {
 		super.init();
-
-		configurationManager = new ServerConfigurationManager(new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
-
-		configurationManager.applyConfiguration(new File(getESBResourceLocation() + File.separator +
-		                                                                                "synapseconfig" +
-		                                                                                File.separator +
-		                                                                                "nonBlockingHTTP" +
-		                                                                                File.separator +
-		                                                                                "axis2.xml"));
-
-		super.init(); // After restarting, this will establish the sessions.
 		logViewer = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
 		uploadSynapseConfig();
 	}
@@ -81,10 +69,8 @@ public class ESBJAVA2464TestCase extends ESBIntegrationTest {
 
 	@AfterClass(alwaysRun = true)
 	public void destroy() throws Exception {
-
 		// Restore the axis2 configuration altered by this test case
 		super.cleanup();
-		configurationManager.restoreToLastConfiguration();
 	}
 
 }

--- a/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSCAppDeploymentWithFaultyProxyTestCase.java
+++ b/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/JMSCAppDeploymentWithFaultyProxyTestCase.java
@@ -37,25 +37,10 @@ public class JMSCAppDeploymentWithFaultyProxyTestCase extends
 	private boolean isCarFileUploaded = false;
 	private ServiceAdminClient serviceAdminClient;
 	private final String proxyServiceName = "JMSProxyWQConf";
-	private ServerConfigurationManager configurationManager;
 
 	@BeforeClass(alwaysRun = true)
 	protected void uploadCarFileTest() throws Exception {
 		
-		super.init();
-
-		configurationManager = new ServerConfigurationManager(new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
-		configurationManager.applyConfiguration(new File(getESBResourceLocation() + File.separator +
-		                                                 "jms" +
-		                                                 File.separator+
-		                                                 "transport"+
-		                                                 File.separator +
-		                                                 "axis2config" +
-		                                                 File.separator +
-		                                                 "activemq"+
-		                                                 File.separator+
-		                                                 "axis2.xml"));
-
 		super.init();
 
 		carbonAppUploaderClient = new CarbonAppUploaderClient(
@@ -72,8 +57,6 @@ public class JMSCAppDeploymentWithFaultyProxyTestCase extends
 			verifyUndeployment();
 			super.cleanup();
 		}
-        configurationManager.restoreToLastConfiguration();
-        configurationManager = null;
 	}
 
 	@Test(groups = { "wso2.esb" }, description = "faulty proxy service deployment from car file")


### PR DESCRIPTION
Axis2 configuration changes removed since its already applied at package level in JMSBrokerStartupTestCase