### PR TITLE
http.socket.reuseaddr=true parameter added to configuration files

### DIFF
--- a/modules/distribution/src/main/conf/nhttp.properties
+++ b/modules/distribution/src/main/conf/nhttp.properties
@@ -46,3 +46,6 @@ nhttp.rest.dispatcher.service=__MultitenantDispatcherService
 # URI configurations that determine if it requires custom rest dispatcher
 rest_uri_api_regex=\\w+://.+:\\d+/t/.*|\\w+://.+\\w+/t/.*|^(/t/).*
 rest_uri_proxy_regex=\\w+://.+:\\d+/services/t/.*|\\w+://.+\\w+/services/t/.*|^(/services/t/).*
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-mediator-2/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-other/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-sample/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-service/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/inbound/transport/test/JMSInboundMessagePollingTestCase.java
+++ b/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/jms/inbound/transport/test/JMSInboundMessagePollingTestCase.java
@@ -86,6 +86,7 @@ public class JMSInboundMessagePollingTestCase extends ESBIntegrationTest{
 		} finally {
 			sender.disconnect();
 		}
+        Thread.sleep(10000);
 
 		int beforeLogCount = logViewerClient.getAllSystemLogs().length;
 		addInboundEndpoint(addEndpoint1());

--- a/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-ui-integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
+++ b/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/nhttp.properties
@@ -50,3 +50,6 @@ lst_t_max=1
 
 max_open_connections=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
+++ b/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/MaxOpenConnections/passthru-http.properties
@@ -30,3 +30,6 @@ max_open_connections=2
 #http.user.agent.preserve=false
 #http.server.preserve=true
 #http.connection.disable.keepalive=false
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true

--- a/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
+++ b/modules/integration/tests-ui/src/test/resources/artifacts/ESB/synapseconfig/nhttp_transport/nhttp.properties
@@ -38,3 +38,6 @@ http.nio.interest-ops-queueing=true
 #lst_qlen=-1
 #lst_io_threads=2
 nhttp.rest.dispatcher.service=__MultitenantDispatcherService
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true


### PR DESCRIPTION
 Added to all nhttp and passthru property files. This is required for test cases to avoid port bind exception at restarts.