### PR TITLE
 Fix sample 370 and 371 by using MediatorThrottleAssertion to correctly render policy configuration in ESB design view

### DIFF
--- a/modules/samples/product/src/main/conf/synapse/synapse_sample_370.xml
+++ b/modules/samples/product/src/main/conf/synapse/synapse_sample_370.xml
@@ -28,9 +28,9 @@
                     <!-- define throttle policy -->
                     <wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
                                 xmlns:throttle="http://www.wso2.org/products/wso2commons/throttle">
-                        <throttle:ThrottleAssertion>
+                        <throttle:MediatorThrottleAssertion>
                             <throttle:MaximumConcurrentAccess>10</throttle:MaximumConcurrentAccess>
-                        </throttle:ThrottleAssertion>
+                        </throttle:MediatorThrottleAssertion>
                     </wsp:Policy>
                 </policy>
                 <onAccept>

--- a/modules/samples/product/src/main/conf/synapse/synapse_sample_371.xml
+++ b/modules/samples/product/src/main/conf/synapse/synapse_sample_371.xml
@@ -28,55 +28,57 @@
                     <!-- define throttle policy -->
                     <wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
                                 xmlns:throttle="http://www.wso2.org/products/wso2commons/throttle">
-                        <throttle:ThrottleAssertion>
-                            <wsp:All>
+                        <throttle:MediatorThrottleAssertion>
+                            <wsp:Policy>
                                 <throttle:ID throttle:type="IP">other</throttle:ID>
-                                <wsp:ExactlyOne>
-                                    <wsp:All>
+                                <wsp:Policy>
+                                    <throttle:Control>
+					<wsp:Policy>
                                         <throttle:MaximumCount>4</throttle:MaximumCount>
                                         <throttle:UnitTime>800000</throttle:UnitTime>
                                         <throttle:ProhibitTimePeriod wsp:Optional="true">10000
                                         </throttle:ProhibitTimePeriod>
-                                    </wsp:All>
-                                    <throttle:IsAllow>true</throttle:IsAllow>
-                                </wsp:ExactlyOne>
-                            </wsp:All>
-                            <wsp:All>
+					</wsp:Policy>
+                                    </throttle:Control>
+                                </wsp:Policy>
+                            </wsp:Policy>
+                            <wsp:Policy>
                                 <throttle:ID throttle:type="IP">192.168.8.200-192.168.8.222
                                 </throttle:ID>
-                                <wsp:ExactlyOne>
-                                    <wsp:All>
+                                <wsp:Policy>
+                                    <throttle:Control>
+					<wsp:Policy>
                                         <throttle:MaximumCount>8</throttle:MaximumCount>
                                         <throttle:UnitTime>800000</throttle:UnitTime>
                                         <throttle:ProhibitTimePeriod wsp:Optional="true">10
                                         </throttle:ProhibitTimePeriod>
-                                    </wsp:All>
-                                    <throttle:IsAllow>true</throttle:IsAllow>
-                                </wsp:ExactlyOne>
-                            </wsp:All>
-                            <wsp:All>
+					</wsp:Policy>
+                                    </throttle:Control>
+                                </wsp:Policy>
+                            </wsp:Policy>
+                            <wsp:Policy>
                                 <throttle:ID throttle:type="IP">192.168.8.201</throttle:ID>
-                                <wsp:ExactlyOne>
-                                    <wsp:All>
+                                <wsp:Policy>
+                                    <throttle:Control>
+					<wsp:Policy>
                                         <throttle:MaximumCount>200</throttle:MaximumCount>
                                         <throttle:UnitTime>600000</throttle:UnitTime>
-                                        <throttle:ProhibitTimePeriod wsp:Optional="true"/>
-                                    </wsp:All>
-                                    <throttle:IsAllow>true</throttle:IsAllow>
-                                </wsp:ExactlyOne>
-                            </wsp:All>
-                            <wsp:All>
+					</wsp:Policy>
+                                    </throttle:Control>
+                                </wsp:Policy>
+                            </wsp:Policy>
+                            <wsp:Policy>
                                 <throttle:ID throttle:type="IP">192.168.8.198</throttle:ID>
-                                <wsp:ExactlyOne>
-                                    <wsp:All>
+                                <wsp:Policy>
+                                    <throttle:Control>
+					<wsp:Policy>
                                         <throttle:MaximumCount>50</throttle:MaximumCount>
                                         <throttle:UnitTime>500000</throttle:UnitTime>
-                                        <throttle:ProhibitTimePeriod wsp:Optional="true"/>
-                                    </wsp:All>
-                                    <throttle:IsAllow>true</throttle:IsAllow>
-                                </wsp:ExactlyOne>
-                            </wsp:All>
-                        </throttle:ThrottleAssertion>
+					</wsp:Policy>
+                                    </throttle:Control>
+                                </wsp:Policy>
+                            </wsp:Policy>
+                        </throttle:MediatorThrottleAssertion>
                     </wsp:Policy>
                 </policy>
                 <onAccept>


### PR DESCRIPTION
Synapse Sample 371 uses "ThrottleAssertion" to define throttle policy and it is not rendered correctly in WSO2 ESB design view.

When a policy is directly created using WSO2 ESB design view, "MediatorThrottleAssertion" is used instead of "ThrottleAssertion".

It seems like use of "ThrottleAssertion" has been deprecated in favour of "MediatorThrottleAssertion" (email was sent to dev list to confirm on this). Therefore, with this pull request, corrected sample 370 and 371 to use "MediatorThrottleAssertion".
