### PR TITLE
Making statistics enabled out-of-box

### DIFF
--- a/modules/distribution/src/main/conf/synapse.properties
+++ b/modules/distribution/src/main/conf/synapse.properties
@@ -56,7 +56,7 @@ synapse.debugger.port.command=9005
 synapse.debugger.port.event=9006
 
 # Configuration to enable mediation flow analytics
-mediation.flow.statistics.enable=false
+mediation.flow.statistics.enable=true
 mediation.flow.statistics.tracer.collect.payloads=false
 mediation.flow.statistics.tracer.collect.properties=false
 mediation.flow.statistics.queue.size=10000


### PR DESCRIPTION
Making statistics enabled out-of-box

```
mediation.flow.statistics.enable=true
```