### PR TITLE
Temporary disabling statistics since serialization method

### DIFF
--- a/modules/integration/tests-integration/tests-other/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-other/src/test/resources/testng.xml
@@ -81,7 +81,7 @@
         </packages>
     </test>
 
-    <test name="Stats-Test" preserve-order="true" verbose="2">
+    <test name="Stats-Test" preserve-order="true" verbose="2" enabled="false">
         <packages>
             <package name="org.wso2.carbon.esb.statistics"/>
         </packages>


### PR DESCRIPTION
Temporary disabling statistics since serialization method is still under discussion for optimizing