### PR TITLE
[ESBJAVA4702] Adding tests for ESBJAVA4702 - Can't read any custom JMS properties with inbound endpoints

### DIFF
--- a/modules/integration/test-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
+++ b/modules/integration/test-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
@@ -179,6 +179,24 @@ public class StockQuoteClient {
         }
     }
 
+    /**
+     * This method utilises serviceClient's sendRobust() method
+     *
+     * @param trpUrl transport url
+     * @param addUrl address url
+     * @param action action
+     * @param payload payload
+     * @throws AxisFault if error occurs in sending the request
+     */
+    public void sendRobust(String trpUrl, String addUrl, String action, OMElement payload) throws AxisFault {
+
+        ServiceClient serviceClient = getServiceClient(trpUrl, addUrl, action);
+        try {
+            serviceClient.sendRobust(payload);
+        } finally {
+            serviceClient.cleanupTransport();
+        }
+    }
 
     public OMElement sendCustomQuoteRequestREST(String trpUrl, String addUrl, String symbol)
             throws AxisFault {

--- a/modules/integration/tests-integration/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA4702JMSHeaderTest.java
+++ b/modules/integration/tests-integration/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA4702JMSHeaderTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.esb.jms.transport.test;
 
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axis2.AxisFault;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -42,22 +43,17 @@ import java.rmi.RemoteException;
  * https://wso2.org/jira/browse/ESBJAVA-4702
  */
 public class ESBJAVA4702JMSHeaderTest extends ESBIntegrationTest {
-    private ServerConfigurationManager serverConfigurationManager;
     private InboundAdminClient inboundAdminClient;
     private LogViewerClient logViewerClient;
-    private ActiveMQServer activeMQServer = new ActiveMQServer();
 
     /**
      * This method initializes an activeMQ server and adds relevant synapse configs to the ESB instance
      *
      * @throws Exception if error occurs in super.init call
      */
-    @BeforeClass(alwaysRun = true) public void init() throws Exception {
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
         super.init();
-        activeMQServer.startJMSBrokerAndConfigureESB();
-        super.init();
-        serverConfigurationManager = new ServerConfigurationManager(
-                new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
         OMElement synapse = esbUtils.loadResource("artifacts/ESB/jms/transport/ESBJAVA4702synapseconfig.xml");
         updateESBConfiguration(JMSEndpointManager.setConfigurations(synapse));
         inboundAdminClient = new InboundAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
@@ -72,8 +68,8 @@ public class ESBJAVA4702JMSHeaderTest extends ESBIntegrationTest {
      * @throws LogViewerLogViewerException if logviewer is not initialized properly
      * @throws InterruptedException if thread.sleep call is interrupted
      */
-    @Test(groups = {
-            "wso2.esb" }, description = "Test JMS Headers : ESBJAVA-4702") public void JMSInboundEndpointHeaderTest()
+    @Test(groups = {"wso2.esb" }, description = "Test JMS Headers : ESBJAVA-4702")
+    public void JMSInboundEndpointHeaderTest()
             throws RemoteException, XMLStreamException, LogViewerLogViewerException, InterruptedException {
         logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
         logViewerClient.clearLogs();
@@ -87,12 +83,12 @@ public class ESBJAVA4702JMSHeaderTest extends ESBIntegrationTest {
                 isHeaderSet = true;
             }
         }
-        Assert.assertEquals(isHeaderSet, true);
+        Assert.assertTrue(isHeaderSet);
     }
 
-    @AfterClass(alwaysRun = true) public void destroy() throws Exception {
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
         super.cleanup();
-        activeMQServer.stopJMSBrokerRevertESBConfiguration();
     }
 
     /**

--- a/modules/integration/tests-integration/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA4702JMSHeaderTest.java
+++ b/modules/integration/tests-integration/tests-patches/src/test/java/org/wso2/carbon/esb/jms/transport/test/ESBJAVA4702JMSHeaderTest.java
@@ -1,0 +1,129 @@
+/*
+*  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.esb.jms.transport.test;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
+import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
+import org.wso2.carbon.logging.view.stub.LogViewerLogViewerException;
+import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
+import org.wso2.esb.integration.common.clients.inbound.endpoint.InboundAdminClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.JMSEndpointManager;
+import org.wso2.esb.integration.common.utils.servers.ActiveMQServer;
+
+import javax.xml.stream.XMLStreamException;
+import java.rmi.RemoteException;
+
+/**
+ * https://wso2.org/jira/browse/ESBJAVA-4702
+ */
+public class ESBJAVA4702JMSHeaderTest extends ESBIntegrationTest {
+    private ServerConfigurationManager serverConfigurationManager;
+    private InboundAdminClient inboundAdminClient;
+    private LogViewerClient logViewerClient;
+    private ActiveMQServer activeMQServer = new ActiveMQServer();
+
+    /**
+     * This method initializes an activeMQ server and adds relevant synapse configs to the ESB instance
+     *
+     * @throws Exception if error occurs in super.init call
+     */
+    @BeforeClass(alwaysRun = true) public void init() throws Exception {
+        super.init();
+        activeMQServer.startJMSBrokerAndConfigureESB();
+        super.init();
+        serverConfigurationManager = new ServerConfigurationManager(
+                new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
+        OMElement synapse = esbUtils.loadResource("artifacts/ESB/jms/transport/ESBJAVA4702synapseconfig.xml");
+        updateESBConfiguration(JMSEndpointManager.setConfigurations(synapse));
+        inboundAdminClient = new InboundAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
+        addInboundEndpoint(addEndpoint());
+    }
+
+    /**
+     * This tests whether the JMS headers are set when reading the headers using an inbound endpoint
+     *
+     * @throws RemoteException if error occurs in sending the request or reading the logs
+     * @throws XMLStreamException if error occurs in reading the payload
+     * @throws LogViewerLogViewerException if logviewer is not initialized properly
+     * @throws InterruptedException if thread.sleep call is interrupted
+     */
+    @Test(groups = {
+            "wso2.esb" }, description = "Test JMS Headers : ESBJAVA-4702") public void JMSInboundEndpointHeaderTest()
+            throws RemoteException, XMLStreamException, LogViewerLogViewerException, InterruptedException {
+        logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+        logViewerClient.clearLogs();
+        axis2Client.sendRobust(getProxyServiceURLHttp("JMSProxy"), null, null, AXIOMUtil.stringToOM("<body/>"));
+        Thread.sleep(5000);
+        boolean isHeaderSet = false;
+        LogEvent[] logs = logViewerClient.getAllRemoteSystemLogs();
+        for (LogEvent event : logs) {
+            String message = event.getMessage();
+            if (message.contains("Producer_Log = MDM")) {
+                isHeaderSet = true;
+            }
+        }
+        Assert.assertEquals(isHeaderSet, true);
+    }
+
+    @AfterClass(alwaysRun = true) public void destroy() throws Exception {
+        super.cleanup();
+        activeMQServer.stopJMSBrokerRevertESBConfiguration();
+    }
+
+    /**
+     * Provides the endpoint definition as an OMElement
+     *
+     * @return an OMElement of the endpoint definition
+     * @throws XMLStreamException if error occurs when reading the xml
+     */
+    private OMElement addEndpoint() throws XMLStreamException {
+        OMElement synapseConfig = null;
+        synapseConfig = AXIOMUtil.stringToOM("<inboundEndpoint xmlns=\"http://ws.apache.org/ns/synapse\"\n" +
+                "                 name=\"JMSIE\"\n" +
+                "                 sequence=\"LogSequence\"\n" +
+                "                 onError=\"inFault\"\n" +
+                "                 protocol=\"jms\"\n" +
+                "                 suspend=\"false\">\n" +
+                "    <parameters>\n" +
+                "        <parameter name=\"interval\">1000</parameter>\n" +
+                "        <parameter name=\"transport.jms.Destination\">testqueue</parameter>\n" +
+                "        <parameter name=\"transport.jms.CacheLevel\">0</parameter>\n" +
+                "        <parameter name=\"transport.jms" +
+                ".ConnectionFactoryJNDIName\">QueueConnectionFactory</parameter>\n" +
+                "        <parameter name=\"java.naming.factory.initial\">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>\n"
+                +
+                "        <parameter name=\"java.naming.provider.url\">tcp://localhost:61616</parameter>\n" +
+                "        <parameter name=\"transport.jms.SessionAcknowledgement\">AUTO_ACKNOWLEDGE</parameter>\n" +
+                "        <parameter name=\"transport.jms.SessionTransacted\">false</parameter>\n" +
+                "        <parameter name=\"transport.jms.ConnectionFactoryType\">queue</parameter>\n" +
+                "    </parameters>\n" +
+                "</inboundEndpoint>");
+
+        return synapseConfig;
+    }
+}

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/jms/transport/ESBJAVA4702synapseconfig.xml
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/artifacts/ESB/jms/transport/ESBJAVA4702synapseconfig.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <proxy name="JMSProxy" startOnLoad="true" trace="disable" transports="http https">
+        <description/>
+        <target>
+            <inSequence>
+                <property name="OUT_ONLY" value="true"/>
+                <property name="Producer" scope="transport"
+                          type="STRING" value="MDM"/>
+                <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2"/>
+            </inSequence>
+            <outSequence>
+                <send/>
+            </outSequence>
+            <endpoint>
+                <address uri="jms:/testqueue?transport.jms.DestinationType=queue&amp;java.naming.provider.url=tcp://localhost:61616&amp;java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;transport.jms.ConnectionFactoryType=queue&amp;transport.jms.ConnectionFactoryJNDIName=QueueConnectionFactory"/>
+            </endpoint>
+        </target>
+    </proxy>
+    <sequence name="LogSequence">
+        <log level="custom">
+            <property expression="get-property('transport', 'Producer')"
+                      name="Producer_Log" xmlns:ns="http://org.apache.synapse/xsd"/>
+        </log>
+    </sequence>
+    <sequence name="fault">
+        <!-- Log the message at the full log level with the ERROR_MESSAGE and the ERROR_CODE-->
+        <log level="full">
+            <property name="MESSAGE" value="Executing default 'fault' sequence"/>
+            <property expression="get-property('ERROR_CODE')" name="ERROR_CODE"/>
+            <property expression="get-property('ERROR_MESSAGE')" name="ERROR_MESSAGE"/>
+        </log>
+        <!-- Drops the messages by default if there is a fault -->
+        <drop/>
+    </sequence>
+    <sequence name="main">
+        <in>
+            <!-- Log all messages passing through -->
+            <log level="full"/>
+            <!-- ensure that the default configuration only sends if it is one of samples -->
+            <!-- Otherwise Synapse would be an open proxy by default (BAD!)               -->
+            <filter regex="http://localhost:9000.*" source="get-property('To')">
+                <!-- Send the messages where they have been sent (i.e. implicit "To" EPR) -->
+                <send/>
+            </filter>
+        </in>
+        <out>
+            <send/>
+        </out>
+        <description>The main sequence for the message mediation</description>
+    </sequence>
+    <!-- You can add any flat sequences, endpoints, etc.. to this synapse.xml file if you do
+    *not* want to keep the artifacts in several files -->
+</definitions>

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
@@ -280,5 +280,10 @@
             <class name="org.wso2.carbon.esb.mediators.clone.ESBJAVA4913HandleExceptionTest"/>
         </classes>
     </test>
+    <test name="ESBJAVA4702" preserve-order="true" verbose="2">
+        <classes>
+            <class name="org.wso2.carbon.esb.jms.transport.test.ESBJAVA4702JMSHeaderTest"/>
+        </classes>
+    </test>
 </suite>
 

--- a/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-patches/src/test/resources/testng.xml
@@ -110,6 +110,7 @@
             <class name="org.wso2.carbon.esb.jms.transport.test.ESBJAVA3282CalloutJMSHeadersTestCase" />
             <class name="org.wso2.carbon.esb.mediators.store.ESBJAVA4470StoreMediatorEmptyOMArraySerializeException" />
             <class name="org.wso2.carbon.esb.jms.transport.test.ESBJAVA4692_MP_FaultSequence_HttpsEndpoint_TestCase" />
+            <class name="org.wso2.carbon.esb.jms.transport.test.ESBJAVA4702JMSHeaderTest"/>
         </classes>
     </test>
 
@@ -278,11 +279,6 @@
     <test name="ESBJAVA_4913" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.carbon.esb.mediators.clone.ESBJAVA4913HandleExceptionTest"/>
-        </classes>
-    </test>
-    <test name="ESBJAVA4702" preserve-order="true" verbose="2">
-        <classes>
-            <class name="org.wso2.carbon.esb.jms.transport.test.ESBJAVA4702JMSHeaderTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
This contains the test cases for https://wso2.org/jira/browse/ESBJAVA-4702 . JMS properties were not set when they were read inside inbound endpoints. This test case tests whether the fix for it works.