### PR TITLE
Added test cases for arbitrary file retrieval out side jar security test

### DIFF
--- a/modules/integration/tests-integration/tests-other/src/test/java/org/wso2/carbon/esb/security/test/tryit/ResourceRetrievalUsingWsdl2Form.java
+++ b/modules/integration/tests-integration/tests-other/src/test/java/org/wso2/carbon/esb/security/test/tryit/ResourceRetrievalUsingWsdl2Form.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.esb.security.test.tryit;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This test class will test whether using ?wsdl2form&contentType=text/html&resource=. user will be able to read
+ * files outside the JAR.
+ */
+public class ResourceRetrievalUsingWsdl2Form extends ESBIntegrationTest {
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+        super.init();
+    }
+
+    @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
+    @Test(groups = "wso2.esb", description = "Tests wsdl2form arbitrary file retrieval")
+    public void testResourceRetrievalUsingWsdl2Form() throws InterruptedException, IOException {
+        int expectedStatusCode = 400;
+        String url = "https://localhost:9643/services/echo?wsdl2form&contentType=text/html&resource=.";
+        URL connectionURL = new URL(url);
+        HttpURLConnection connection = (HttpURLConnection) connectionURL.openConnection();
+        connection.setRequestMethod("GET");
+        int actualStatusCode = connection.getResponseCode();
+        assertEquals(actualStatusCode, expectedStatusCode, "Response status code should be " + expectedStatusCode
+                + " but received " + actualStatusCode);
+    }
+}

--- a/modules/integration/tests-integration/tests-other/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-other/src/test/resources/testng.xml
@@ -44,10 +44,10 @@
             <class name="org.wso2.carbon.esb.test.servers.CarbonTestServerManager"/>
             <class name="org.wso2.carbon.esb.test.servers.NewInstanceTestCase"/>
             <class name="org.wso2.carbon.esb.test.servers.OSGIUnsatisfiedServerBundlesTestCase">
-		<methods>
+                <methods>
                     <exclude name=".*"/>
                 </methods>
-	    </class>
+            </class>
         </classes>
     </test>
 
@@ -100,7 +100,11 @@
         </packages>
     </test>
 
-
+    <test name="Security-Test-Tryit" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.security.test.tryit.*"/>
+        </packages>
+    </test>
 </suite>
 
 


### PR DESCRIPTION
Related fix for carbon-commons : https://github.com/wso2-support/carbon-commons/pull/35