### PR TITLE
Test accessing swagger.json of an API

### DIFF
--- a/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA5069AccessSwaggerTenantTestCase.java
+++ b/modules/integration/tests-integration/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA5069AccessSwaggerTenantTestCase.java
@@ -1,0 +1,66 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.esb.passthru.transport.test;
+
+
+import org.apache.axis2.AxisFault;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.carbon.automation.test.utils.http.client.HttpURLConnectionClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This class tests the scenario: in the tenant space, accessing swager.json of an API
+ * https://wso2.org/jira/browse/ESBJAVA-5069
+ */
+
+public class ESBJAVA5069AccessSwaggerTenantTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init(TestUserMode.TENANT_ADMIN);
+        String artifactPath = "artifacts" + File.separator + "ESB" + File.separator + "api" + File.separator
+                + "Tenant.xml";
+        loadESBConfigurationFromClasspath(artifactPath);
+    }
+
+    @Test(groups = "wso2.esb", description = "Passthru  test case for tenant" )
+    public void accessSwagerTest() throws AxisFault {
+        try {
+            String swaggerURL = getApiInvocationURL("testapi").replace("services/", "");
+            HttpResponse response = HttpURLConnectionClient.
+                    sendGetRequest(swaggerURL, null);
+            Assert.assertNotNull(response, "Swagger.json is accessible");
+        } catch (IOException e) {
+            Assert.fail("Error while accessing the Swagger.json", e);
+        }
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+
+}

--- a/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/api/Tenant.xml
+++ b/modules/integration/tests-integration/tests-transport/src/test/resources/artifacts/ESB/api/Tenant.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <api name="testapi" context="/t/wso2.com/testapi">
+        <resource methods="GET">
+            <inSequence>
+                <log level="custom">
+                    <property name="TEST_TENANT_API" value="TEST_TENANT_API"/>
+                </log>
+                <respond/>
+            </inSequence>
+        </resource>
+    </api>
+ </definitions>


### PR DESCRIPTION
This is to add a testcase for https://wso2.org/jira/browse/ESBJAVA-5069
Scenario: in the tenant space, accessing swagger.json of an API