### PR TITLE
Update synapse and mediation to latest snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1084,7 +1084,7 @@
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
 
         <!-- Synapse -->
-        <synapse.version>2.1.7-wso2v15-SNAPSHOT</synapse.version>
+        <synapse.version>2.1.7-wso2v16-SNAPSHOT</synapse.version>
 
         <!-- Axis2 Transport -->
         <axis2.transport.version>2.0.0-wso2v3-SNAPSHOT</axis2.transport.version>
@@ -1093,7 +1093,7 @@
         <org.apache.httpcomponents.wso2.version>4.2.3.wso2v1</org.apache.httpcomponents.wso2.version>
 
         <!-- Carbon mediation version -->
-        <carbon.mediation.version>4.6.19-SNAPSHOT</carbon.mediation.version>
+        <carbon.mediation.version>4.6.20-SNAPSHOT</carbon.mediation.version>
 
         <!-- Carbon kernel version-->
         <carbon.kernel.version>4.4.9</carbon.kernel.version>


### PR DESCRIPTION
Updated versions as follows,
synapse.version: 2.1.7-wso2v16-SNAPSHOT
carbon.mediation.version: 4.6.20-SNAPSHOT

Note that carbon mediation v4.6.19 is released on carbon kernel v4.4.16. But product-esb is still in kernel version v4.4.9.  