### PR TITLE
Change synape, mediation versions to stable releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1084,7 +1084,7 @@
         <axiom.wso2.version>1.2.11.wso2v10</axiom.wso2.version>
 
         <!-- Synapse -->
-        <synapse.version>2.1.7-wso2v14</synapse.version>
+        <synapse.version>2.1.7-wso2v13</synapse.version>
 
         <!-- Axis2 Transport -->
         <axis2.transport.version>2.0.0-wso2v2</axis2.transport.version>
@@ -1093,7 +1093,7 @@
         <org.apache.httpcomponents.wso2.version>4.2.3.wso2v1</org.apache.httpcomponents.wso2.version>
 
         <!-- Carbon mediation version -->
-        <carbon.mediation.version>4.6.17</carbon.mediation.version>
+        <carbon.mediation.version>4.6.16</carbon.mediation.version>
 
         <!-- Carbon kernel version-->
         <carbon.kernel.version>4.4.9</carbon.kernel.version>


### PR DESCRIPTION
This version downgrade was done because previous synapse and mediation versions contained a change in payload factory mediator which can break some connectors that have used payload factory mediator. In laster versions of synapse and mediation this issue has been fixed but those versions are using new carbon-kernel version, therefore upgrading the kernel will require further testing. 
Until that is done, this version downgrade will make the product-esb stable.